### PR TITLE
Fix generate-tar on ppc64 hosts

### DIFF
--- a/generate-tar
+++ b/generate-tar
@@ -152,7 +152,7 @@ mkdir ${pnor_dir}
 
 pflash --partition=part --read=${pnor_dir}/part -F ${pnorfile}
 pflash --partition=VERSION --read=${pnor_dir}/VERSION -F ${pnorfile}
-version_size=$(du -k ${pnor_dir}/VERSION | head -1 | cut -f 1)
+version_size=$(du -bk ${pnor_dir}/VERSION | head -1 | cut -f 1)
 magic_number=$(xxd -p -l 4 ${pnor_dir}/VERSION)
 # Check if VERSION is signed. A signed version partition will have an extra
 # 4K header starting with the magic number 0x17082011, see:


### PR DESCRIPTION
Currently the tarball MANIFEST is garbaled when building the tarball on
a ppc64 host. This is because the check to determine if the secureboot
header needs to be removed is sensitive to the system page size. By
default the scratch directory used when running generate-tar is placed
in /tmp. Typically this is a tmpfs file system which has a minimum block
of one system page, which is 64KB on ppc64.

We use the du utility to calculate the size of the VERSION partition and
when a file is smaller than the file systems minimum allocation block it
gives an unexpected result:

$ du -k /tmp/tmp.BhDKg0pQGF/VERSION
64	/tmp/tmp.BhDKg0pQGF/VERSION

$ du -bk /tmp/tmp.BhDKg0pQGF/VERSION
8	/tmp/tmp.BhDKg0pQGF/VERSION

We can fix this by passing the '-b' parameter to du to make it ignore
the filesystem block size.

Signed-off-by: Oliver O'Halloran <oohall@gmail.com>