### PR TITLE
Guard: Guarded DIMMS/CPU are not enabled back after factory reset

### DIFF
--- a/mmc/item_updater_mmc.hpp
+++ b/mmc/item_updater_mmc.hpp
@@ -20,6 +20,17 @@ class GardResetMMC : public GardReset
      * @brief GARD factory reset - clears the PNOR GARD partition.
      */
     void reset() override;
+
+  private:
+    /**
+     * Dimm/CPU enable property will be false if there are assosiated guard
+     * record. The disabled dimm/cpu are not reset after host clears the guard
+     * partition during factory reset.
+     * Due to this there is inconsitency and user is not able to enable the
+     * guarded dimms/cpus. Modified to force enable all the guard/dimms during
+     * factory reset
+     */
+    void enableDimmAndCpu();
 };
 
 /** @class ItemUpdaterMMC


### PR DESCRIPTION
User not able to enable some of the guarded dimm/cpu after host factory reset even thogh host cleared the guards in the guard
partition. BMC will not know host took a factory reset for it to clear the disabled flag for the earlier guarded dimm/cpu. Modified to force enable all the cpu/dimm during host factory reset.

test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8
test[4354]: enable /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>`
Change-Id: I4589047e36917c295ab0333ccc9ac3e35a25ec0c